### PR TITLE
bugfix/accurics_remediation_6006186081404705 - Auto Generated Pull Request From Accurics

### DIFF
--- a/vpc.tf
+++ b/vpc.tf
@@ -22,7 +22,7 @@ resource "aws_subnet" "public" {
   vpc_id                  = aws_vpc.vpc.id
   cidr_block              = cidrsubnets("10.0.0.0/16", 8, 8)[count.index]
   availability_zone       = data.aws_availability_zones.available.names[count.index]
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = false
 
   tags = {
     Name = "${local.prefix.value}-subnet-${count.index}"


### PR DESCRIPTION
All subnets have an attribute that determines whether a network interface created in the subnet automatically receives a public IPv4 address. Therefore, it is recommended to set it to FALSE. In AWS Console - 
 1. Sign in to the AWS Console and go to the VPC dashboard.
 2. In the navigation pane, select subnets.
 3. Select your subnet and then choose Subnet Actions, Modify auto-assign IP settings.
 4. Clear the Enable auto-assign public IPv4 address check box and then choose Save.
 In terraform - Modify 'aws_subnet' resource and set 'map_public_ip_on_launch' to false.